### PR TITLE
fix sender waits until receiver attaches

### DIFF
--- a/include/rohrkabel/channel/channel.inl
+++ b/include/rohrkabel/channel/channel.inl
@@ -29,7 +29,10 @@ namespace pipewire
     {
         auto receive = [this, callback = std::forward<Callback>(callback)]()
         {
-            cr::receiver<T>::recv(callback);
+            while (auto opt = cr::receiver<T>::try_recv())
+            {
+                std::visit(callback, *opt);
+            }
         };
 
         m_state->attach(std::move(loop), std::move(receive));

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -55,6 +55,10 @@ namespace pipewire
 
     void channel_state::emit()
     {
+        if (m_impl->source.wait_for(std::chrono::milliseconds{0}) != std::future_status::ready)
+        {
+            throw std::runtime_error{"no receiver available"};
+        }
         auto *source = m_impl->source.get();
         pw_loop_signal_event(m_impl->loop->loop(), source);
     }


### PR DESCRIPTION
When no receiver attaches to the channel, the sender might wait infinitely.

My approach here is up to debate. Adding a timeout parameter to `channel_state::emit` would be a more flexible option.

One drawback I ran into using my approach was that the sender could have already put a message into the queue (in `sender<T>::send`), but then fails to emit due to a missing receiver. To cope with that I introduced the draining of the queue in (compare `channel.inl`).